### PR TITLE
Fix V3051

### DIFF
--- a/Translator/MainWindow.xaml.cs
+++ b/Translator/MainWindow.xaml.cs
@@ -1099,11 +1099,11 @@ namespace TTSAutomate
                         //{
                         nextRowCell = (nextRowCell as DataGridCell).PredictFocus(FocusNavigationDirection.Right);
                         //}
-                        int rowselected = PhraseItems.IndexOf(((nextRow as DataGridRow).Item as PhraseItem) as PhraseItem);
+                        int rowselected = PhraseItems.IndexOf((nextRow as DataGridRow).Item as PhraseItem);
                         while (rowselected >= 0 && String.IsNullOrEmpty(PhraseItems[rowselected].Folder)) { rowselected--; } // traverse upwards
                         if (rowselected >= 0)
                         {
-                            (((nextRow as DataGridRow).Item as PhraseItem) as PhraseItem).Folder = PhraseItems[rowselected].Folder;
+                            ((nextRow as DataGridRow).Item as PhraseItem).Folder = PhraseItems[rowselected].Folder;
                             NeedToSave = true;
                         }
                     }


### PR DESCRIPTION
Hello again from Pinguem.ru competition on finding errors. I found some more bugs with PVS-Studio:

- An excessive type cast. The object is already of the 'PhraseItem' type. TTSAutomate MainWindow.xaml.cs 1102

- An excessive type cast. The object is already of the 'PhraseItem' type. TTSAutomate MainWindow.xaml.cs 1106