### PR TITLE
Another one V3025

### DIFF
--- a/Translator/MainWindow.xaml.cs
+++ b/Translator/MainWindow.xaml.cs
@@ -372,7 +372,7 @@ namespace TTSAutomate
                                 }
                                 catch (TagLib.CorruptFileException ex)
                                 {
-                                    Debug.WriteLine("File {1} Exception", ex, item.Phrase);
+                                    Debug.WriteLine("File {1} Exception {0}", ex, item.Phrase);
                                 }
                             }
                         }


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- Incorrect format. A different number of format items is expected while calling 'WriteLine' function. Arguments not used: ex. TTSAutomate MainWindow.xaml.cs 375