### PR TITLE
Fix V3008

### DIFF
--- a/Translator/TTSProvider/IvonaTTSProvider.cs
+++ b/Translator/TTSProvider/IvonaTTSProvider.cs
@@ -213,7 +213,6 @@ namespace TTSAutomate
             webRequest.Headers.Add("X-Amz-date", requestDate);
             webRequest.Headers.Add("Authorization", authorization);
             webRequest.Headers.Add("x-amz-content-sha256", hashedRequestPayload);
-            webRequest.ContentLength = requestPayload.Length;
             webRequest.ContentLength = bytes.Length;
 
             try


### PR DESCRIPTION
Another bug fixes from Pinguem.ru competition found with PVS-Studio:

- The 'webRequest.ContentLength' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 217, 216. TTSAutomate IvonaTTSProvider.cs 217